### PR TITLE
[FE] Input 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Input/index.stories.tsx
+++ b/frontend/src/components/Input/index.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, Story } from '@storybook/react';
+
+import Input, { InputProps } from '.';
+
+export default {
+  title: 'Input',
+  component: Input,
+} as Meta;
+
+const Template: Story<InputProps> = args => <Input {...args} />;
+
+export const DefaultInput = Template.bind({});
+DefaultInput.args = {
+  isValid: true,
+};
+
+export const UnderlineInput = Template.bind({});
+UnderlineInput.args = {
+  isValid: true,
+  hasUnderline: true,
+};

--- a/frontend/src/components/Input/index.styles.tsx
+++ b/frontend/src/components/Input/index.styles.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+const Input = styled.input<{ isValid: boolean }>`
+  ${({ isValid, theme }) => `
+    background: ${isValid ? theme.colors.WHITE_100 : theme.colors.RED_200};
+    color: ${theme.colors.BLACK_500};
+
+    border-color: ${theme.colors.YELLOW_500};
+    border-style: solid;
+  `}
+
+  border-radius: 4px;
+  outline: none;
+
+  font-weight: 700;
+`;
+
+const UnderlineInput = styled(Input)`
+  border: 0;
+  border-radius: 0;
+
+  ${({ theme }) => `
+    border-bottom: 1px solid ${theme.colors.BLACK_500};
+  `}
+`;
+
+export { Input, UnderlineInput };

--- a/frontend/src/components/Input/index.styles.tsx
+++ b/frontend/src/components/Input/index.styles.tsx
@@ -2,11 +2,10 @@ import styled from '@emotion/styled';
 
 const Input = styled.input<{ isValid: boolean }>`
   ${({ isValid, theme }) => `
-    background: ${isValid ? theme.colors.WHITE_100 : theme.colors.RED_200};
+    background: ${isValid ? theme.colors.WHITE_100 : theme.colors.RED_100};
     color: ${theme.colors.BLACK_500};
 
-    border-color: ${theme.colors.YELLOW_500};
-    border-style: solid;
+    border: solid ${theme.colors.YELLOW_500};
   `}
 
   border-radius: 4px;

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -18,14 +18,11 @@ const Input = ({
   ...inputAttribute
 }: InputProps &
   React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>) => {
-  switch (hasUnderline) {
-    case false:
-      return <S.Input type={type} isValid={isValid} {...inputAttribute} />;
-    case true:
-      return <S.UnderlineInput type={type} isValid={isValid} {...inputAttribute} />;
-    default:
-      return <S.Input type={type} isValid={isValid} {...inputAttribute} />;
+  if (hasUnderline) {
+    return <S.UnderlineInput type={type} isValid={isValid} {...inputAttribute} />;
   }
+
+  return <S.Input type={type} isValid={isValid} {...inputAttribute} />;
 };
 
 export default Input;

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { INPUT_TYPE } from '@/constants';
+import { InputType } from '@/types';
+
+import * as S from './index.styles';
+
+export interface InputProps {
+  type?: InputType;
+  isValid?: boolean;
+  hasUnderline?: boolean;
+}
+
+const Input = ({
+  type = INPUT_TYPE.TEXT,
+  isValid = true,
+  hasUnderline = false,
+  ...inputAttribute
+}: InputProps &
+  React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>) => {
+  switch (hasUnderline) {
+    case false:
+      return <S.Input type={type} isValid={isValid} {...inputAttribute} />;
+    case true:
+      return <S.UnderlineInput type={type} isValid={isValid} {...inputAttribute} />;
+    default:
+      return <S.Input type={type} isValid={isValid} {...inputAttribute} />;
+  }
+};
+
+export default Input;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -9,10 +9,16 @@ const BUTTON_TYPE = {
   BUTTON: 'button',
 } as const;
 
+const INPUT_TYPE = {
+  TEXT: 'text',
+  NUMBER: 'number',
+  PASSWORD: 'password',
+} as const;
+
 const ALIGN = {
   LEFT: 'left',
   CENTER: 'center',
   RIGHT: 'right',
 } as const;
 
-export { SIZE, BUTTON_TYPE, ALIGN };
+export { SIZE, BUTTON_TYPE, INPUT_TYPE, ALIGN };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,10 +1,10 @@
 import type { UnionizeKeys, UnionizeValues } from './utils';
-
-import { ALIGN, BUTTON_TYPE, SIZE } from '@/constants';
+import { ALIGN, BUTTON_TYPE, INPUT_TYPE, SIZE } from '@/constants';
 import theme from '@/styles/theme';
 
 export type Size = UnionizeValues<typeof SIZE>;
 export type ButtonType = UnionizeValues<typeof BUTTON_TYPE>;
+export type InputType = UnionizeValues<typeof INPUT_TYPE>;
 export type Align = UnionizeValues<typeof ALIGN>;
 
 declare module '@emotion/react' {


### PR DESCRIPTION
###  개발한 기능 목록 
- Input 컴포넌트 구현

### 구현된 UI 

![image](https://user-images.githubusercontent.com/28296575/208149532-bbbb6308-845a-4c2a-b7b8-76f2af5f0364.png)


### 공유사항 

- 기본 컴포넌트를 만들때 원래 태그가 가지고 있는 값들을 모두 지원해주기 위해 `rest parameter`를 사용하였습니다. 필요하다면 이런식으로 처리해주는게 좋을 것 같네요.
- figma 시안에 따라 인풋에 들어가는 색상이 고정되어 있어서 색상은 따로 변경시켜주지 않도록 했습니다.

close #4 